### PR TITLE
Fix project details view

### DIFF
--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -36,8 +36,8 @@ const ProjectDetail = () => {
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold mb-2">{project.title}</h1>
-      <p className="mb-4 text-gray-700">{project.description}</p>
+      <h1 className="text-2xl font-bold mb-2">{project.name}</h1>
+      <p className="mb-4 text-gray-700">{project.meilensteine}</p>
 
       <h2 className="text-lg font-semibold mt-6 mb-2">📍 Meilensteine</h2>
       {milestones.length > 0 ? (


### PR DESCRIPTION
## Summary
- show project name instead of title in detail page
- display the `meilensteine` text as project description

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev` *(manual check)*

------
https://chatgpt.com/codex/tasks/task_b_688b1a8b78208327aac693eb8ec79cd8