### PR TITLE
Fix German comment on deleteUser

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -79,7 +79,7 @@ const Dashboard = () => {
     fetchProjects();
   }, [role, user]);
 
-  // Account und Daten löschen (ohne Admin-Zugang kein DeleteUser möglich!)
+  // Account und Daten löschen – ohne Admin-Zugang ist deleteUser nicht möglich
   const handleDeleteAccount = async () => {
     if (!user?.id) return;
 


### PR DESCRIPTION
## Summary
- clarify Dashboard comment about lacking admin rights for deleteUser

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688b275d6094832790727856b71531bd