### PR TITLE
Add vitest tests for getUserRole

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.53.0",

--- a/src/utils/__tests__/getUserRole.test.js
+++ b/src/utils/__tests__/getUserRole.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getUserRole } from '../getUserRole.js';
+import { supabase } from '../../supabaseClient.js';
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+describe('getUserRole', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns role when query succeeds', async () => {
+    const single = vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null });
+    supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single,
+    });
+
+    const role = await getUserRole(1);
+    expect(role).toBe('admin');
+  });
+
+  it('returns null when query fails', async () => {
+    const error = new Error('db error');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const single = vi.fn().mockResolvedValue({ data: null, error });
+    supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single,
+    });
+
+    const role = await getUserRole(1);
+    expect(role).toBeNull();
+    expect(console.error).toHaveBeenCalledWith('Fehler beim Abrufen der Rolle:', error);
+    console.error.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add test script using vitest
- write unit tests for getUserRole

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b287f65b48327a3ebc60c32141c55