### PR TITLE
Handle magic link in Verify page

### DIFF
--- a/src/pages/Verify.jsx
+++ b/src/pages/Verify.jsx
@@ -7,6 +7,20 @@ const Verify = () => {
 
   useEffect(() => {
     const confirmUser = async () => {
+      const code = new URLSearchParams(window.location.search).get("code");
+
+      if (code) {
+        const { error: exchangeError } =
+          await supabase.auth.exchangeCodeForSession(code);
+        if (exchangeError) {
+          alert(
+            "Fehler beim Austausch des Verifizierungscodes: " +
+              exchangeError.message
+          );
+          return;
+        }
+      }
+
       const {
         data: { session },
         error: sessionError,


### PR DESCRIPTION
## Summary
- parse `code` from the query string in `Verify` page
- exchange the code for a session before querying the current session
- notify the user on errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688b3921efbc83278656ea38ad3e21df