### PR TITLE
Fix email redirect to use window location

### DIFF
--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -33,7 +33,7 @@ const Register = () => {
           geburtsdatum: form.geburtsdatum,
           matrikelnummer: form.matrikelnummer,
         },
-        emailRedirectTo: "https://frontend-se-cyan.vercel.app/verify", // ← muss exakt zu deinem Projekt passen!
+        emailRedirectTo: `${window.location.origin}/verify`,
       },
     });
 


### PR DESCRIPTION
## Summary
- improve `emailRedirectTo` in `Register.jsx` so the address works in both local and production

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688b3c33e0808327ae6fe3a3c687cc47