### PR TITLE
Improve registration flow and dashboard

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,12 +1,39 @@
 // pages/Home.jsx
-const Home = () => (
-  <div className="p-6">
-    <h1 className="text-2xl font-bold">Willkommen bei MyApp!</h1>
-    <p className="mt-2">
-      Dies ist die Startseite der Software-Engineering Plattform für Tutoren und Studenten. Du kannst dich einloggen oder registrieren.
-    </p>
-    <img src="/myAppPic.jpg" alt="Logo" className="mt-4 rounded shadow-lg h-auto w-auto" />
-    
-  </div>
-);
+import { useEffect, useState } from "react";
+import { supabase } from "../supabaseClient";
+
+const Home = () => {
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(async ({ data: { user } }) => {
+      if (user) {
+        const { data } = await supabase
+          .from("user_profiles")
+          .select("vorname, nachname")
+          .eq("id", user.id)
+          .single();
+        if (data) setProfile(data);
+      }
+    });
+  }, []);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold">
+        Willkommen bei MyApp!
+      </h1>
+      {profile && (
+        <p className="mt-1 text-gray-600">
+          Hallo, {profile.vorname} {profile.nachname}!
+        </p>
+      )}
+      <p className="mt-2">
+        Dies ist die Startseite der Software-Engineering Plattform für Tutoren und Studenten. Du kannst dich einloggen oder registrieren.
+      </p>
+      <img src="/myAppPic.jpg" alt="Logo" className="mt-4 rounded shadow-lg h-auto w-auto" />
+
+    </div>
+  );
+};
 export default Home;

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -43,7 +43,7 @@ const Register = () => {
     }
 
     alert("Registrierung erfolgreich. Bitte bestätige deine E-Mail.");
-    navigate("/verify");
+    navigate("/");
   };
 
   return (

--- a/src/pages/Verify.jsx
+++ b/src/pages/Verify.jsx
@@ -1,13 +1,19 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../supabaseClient";
 
 const Verify = () => {
   const navigate = useNavigate();
+  const [info, setInfo] = useState("Bestätigung läuft...");
 
   useEffect(() => {
     const confirmUser = async () => {
       const code = new URLSearchParams(window.location.search).get("code");
+
+      if (!code) {
+        setInfo("Bitte bestätige deine E-Mail über den zugeschickten Link.");
+        return;
+      }
 
       if (code) {
         const { error: exchangeError } =
@@ -27,7 +33,7 @@ const Verify = () => {
       } = await supabase.auth.getSession();
 
       if (sessionError || !session) {
-        alert("Keine gültige Session gefunden.");
+        setInfo("Keine gültige Session gefunden.");
         return;
       }
 
@@ -48,19 +54,19 @@ const Verify = () => {
       ]);
 
       if (insertError) {
-        alert("Profil konnte nicht gespeichert werden: " + insertError.message);
+        setInfo("Profil konnte nicht gespeichert werden: " + insertError.message);
         return;
       }
 
       sessionStorage.clear();
-      alert("E-Mail bestätigt! Du wirst weitergeleitet...");
-      navigate("/welcome");
+      setInfo("E-Mail bestätigt! Weiterleitung...");
+      setTimeout(() => navigate("/welcome"), 1000);
     };
 
     confirmUser();
   }, [navigate]);
 
-  return null;
+  return <p className="p-6 text-center">{info}</p>;
 };
 
 export default Verify;


### PR DESCRIPTION
## Summary
- greet users on Home once profile exists
- hide register link when logged in and show user name in Navbar
- after sign‑up redirect to the start page
- improve verification page UX
- extend project form with edit mode and file upload
- add full CRUD to dashboard with role checks

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_688b43c52cec8327b78d3443f0320c60