### PR TITLE
Handle verification with getSessionFromUrl

### DIFF
--- a/src/pages/Verify.jsx
+++ b/src/pages/Verify.jsx
@@ -8,36 +8,16 @@ const Verify = () => {
 
   useEffect(() => {
     const confirmUser = async () => {
-      const code = new URLSearchParams(window.location.search).get("code");
+      const { data, error } = await supabase.auth.getSessionFromUrl({
+        storeSession: true,
+      });
 
-      if (!code) {
-        setInfo("Bitte bestätige deine E-Mail über den zugeschickten Link.");
-        return;
-      }
-
-      if (code) {
-        const { error: exchangeError } =
-          await supabase.auth.exchangeCodeForSession(code);
-        if (exchangeError) {
-          alert(
-            "Fehler beim Austausch des Verifizierungscodes: " +
-              exchangeError.message
-          );
-          return;
-        }
-      }
-
-      const {
-        data: { session },
-        error: sessionError,
-      } = await supabase.auth.getSession();
-
-      if (sessionError || !session) {
+      if (error || !data.session) {
         setInfo("Keine gültige Session gefunden.");
         return;
       }
 
-      const user = session.user;
+      const user = data.session.user;
 
       const { vorname, nachname, geburtsdatum, matrikelnummer } =
         user.user_metadata || {};
@@ -54,8 +34,7 @@ const Verify = () => {
       ]);
 
       if (insertError) {
-        setInfo("Profil konnte nicht gespeichert werden: " + insertError.message);
-        return;
+        console.error("Profil konnte nicht gespeichert werden:", insertError);
       }
 
       sessionStorage.clear();


### PR DESCRIPTION
## Summary
- use `getSessionFromUrl` when verifying user email
- insert the profile once the session is returned and redirect to `/welcome`
- only display an error if no session is retrieved

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688b5ecf1d5883279f69f4223303f1e8