### PR TITLE
Update verification flow with exchangeCodeForSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ npm run lint
 
 After registering a user, Supabase sends a dynamic verification link to the provided e-mail address. The link redirects to the `/verify` route in this application where the verification is handled.
 
-When signing up, Supabase emails a dynamic verification link such as `https://localhost:5173/verify?code=...`. After the code is validated, Supabase redirects back to the page with the session tokens placed in the URL fragment, e.g. `https://localhost:5173/verify#access_token=...`. The `Verify.jsx` page uses `supabase.auth.getSessionFromUrl()` to extract those tokens and complete the sign-up flow.
+When signing up, Supabase emails a dynamic verification link such as `https://localhost:5173/verify?code=...`. The `Verify.jsx` page reads this `code` value and calls `supabase.auth.exchangeCodeForSession(code)` to create the session before finishing the sign-up flow.

--- a/src/pages/Verify.jsx
+++ b/src/pages/Verify.jsx
@@ -8,9 +8,11 @@ const Verify = () => {
 
   useEffect(() => {
     const confirmUser = async () => {
-      const { data, error } = await supabase.auth.getSessionFromUrl({
-        storeSession: true,
-      });
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get("code");
+
+      // Exchange the verification code for a session
+      const { data, error } = await supabase.auth.exchangeCodeForSession(code);
 
       if (error || !data.session) {
         setInfo("Keine gültige Session gefunden.");


### PR DESCRIPTION
## Summary
- swap deprecated `getSessionFromUrl` usage with `exchangeCodeForSession`
- clarify README about verification code handling

## Testing
- `npm run lint`
- `npm test -- -t ''`

------
https://chatgpt.com/codex/tasks/task_b_688b6b191c088327bf351b33e2581fae