### PR TITLE
feat: add milestone CRUD

### DIFF
--- a/src/components/MilestoneList.jsx
+++ b/src/components/MilestoneList.jsx
@@ -2,6 +2,16 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../supabaseClient";
 
+// Löscht einen Meilenstein
+export const removeMilestone = async (id) => {
+  const { error } = await supabase.from("milestones").delete().eq("id", id);
+  if (error) {
+    console.error("Fehler beim Löschen des Meilensteins:", error.message);
+    return false;
+  }
+  return true;
+};
+
 // Zeigt alle Meilensteine eines Projekts an
 const MilestoneList = ({ projectId }) => {
   const [milestones, setMilestones] = useState([]);
@@ -24,15 +34,75 @@ const MilestoneList = ({ projectId }) => {
     fetchMilestones();
   }, [projectId]);
 
+  const handleEdit = async (m) => {
+    const title = prompt("Titel", m.title);
+    const description = prompt("Beschreibung", m.description || "");
+    const due_date = prompt(
+      "Fälligkeitsdatum (YYYY-MM-DD)",
+      m.due_date ? m.due_date.split("T")[0] : ""
+    );
+    const status = prompt("Status", m.status || "");
+
+    const updates = { title, description, due_date, status };
+    const { error } = await supabase
+      .from("milestones")
+      .update(updates)
+      .eq("id", m.id);
+
+    if (error) {
+      console.error("Fehler beim Aktualisieren des Meilensteins:", error.message);
+    } else {
+      setMilestones((prev) =>
+        prev.map((ms) => (ms.id === m.id ? { ...ms, ...updates } : ms))
+      );
+    }
+  };
+
+  const handleDelete = async (id) => {
+    const success = await removeMilestone(id);
+    if (success) {
+      setMilestones((prev) => prev.filter((m) => m.id !== id));
+    }
+  };
+
   return (
-    <ul className="mt-2 pl-4 list-disc text-sm text-gray-700">
-      {milestones.map((m) => (
-        <li key={m.id}>
-          {m.completed ? "✅ " : "🔘 "}
-          {m.title}
-        </li>
-      ))}
-    </ul>
+    <table className="w-full text-left border mt-2">
+      <thead>
+        <tr className="bg-gray-200">
+          <th className="p-2 border">Titel</th>
+          <th className="p-2 border">Beschreibung</th>
+          <th className="p-2 border">Fällig bis</th>
+          <th className="p-2 border">Status</th>
+          <th className="p-2 border">Aktionen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {milestones.map((m) => (
+          <tr key={m.id}>
+            <td className="p-2 border">{m.title}</td>
+            <td className="p-2 border">{m.description}</td>
+            <td className="p-2 border">
+              {m.due_date ? new Date(m.due_date).toLocaleDateString() : "-"}
+            </td>
+            <td className="p-2 border">{m.status}</td>
+            <td className="p-2 border space-x-2">
+              <button
+                className="text-blue-600 underline"
+                onClick={() => handleEdit(m)}
+              >
+                Bearbeiten
+              </button>
+              <button
+                className="text-red-600 underline"
+                onClick={() => handleDelete(m.id)}
+              >
+                Löschen
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 };
 

--- a/src/components/__tests__/milestones.test.js
+++ b/src/components/__tests__/milestones.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { addOrUpdateMilestone } from '../../pages/ProjectDetail.jsx';
+import { removeMilestone } from '../MilestoneList.jsx';
+import { supabase } from '../../supabaseClient.js';
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+describe('milestone CRUD', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a milestone when no id is provided', async () => {
+    const single = vi.fn().mockResolvedValue({ data: { id: 1 }, error: null });
+    const select = vi.fn().mockReturnValue({ single });
+    const insert = vi.fn().mockReturnValue({ select });
+    supabase.from.mockReturnValue({ insert });
+
+    const res = await addOrUpdateMilestone(5, {
+      title: 'A',
+      description: 'B',
+      due_date: '2024-01-01',
+      status: 'offen',
+    });
+
+    expect(supabase.from).toHaveBeenCalledWith('milestones');
+    expect(insert).toHaveBeenCalledWith({
+      title: 'A',
+      description: 'B',
+      due_date: '2024-01-01',
+      status: 'offen',
+      project_id: 5,
+    });
+    expect(res).toEqual({ id: 1 });
+  });
+
+  it('updates a milestone when id is provided', async () => {
+    const single = vi.fn().mockResolvedValue({ data: { id: 2 }, error: null });
+    const select = vi.fn().mockReturnValue({ single });
+    const eq = vi.fn().mockReturnValue({ select });
+    const update = vi.fn().mockReturnValue({ eq });
+    supabase.from.mockReturnValue({ update });
+
+    const res = await addOrUpdateMilestone(3, {
+      id: 2,
+      title: 'X',
+      description: 'Y',
+      due_date: '2024-02-02',
+      status: 'done',
+    });
+
+    expect(supabase.from).toHaveBeenCalledWith('milestones');
+    expect(update).toHaveBeenCalledWith({
+      title: 'X',
+      description: 'Y',
+      due_date: '2024-02-02',
+      status: 'done',
+      project_id: 3,
+    });
+    expect(eq).toHaveBeenCalledWith('id', 2);
+    expect(res).toEqual({ id: 2 });
+  });
+
+  it('deletes a milestone', async () => {
+    const eq = vi.fn().mockReturnValue({});
+    const del = vi.fn().mockReturnValue({ eq });
+    supabase.from.mockReturnValue({ delete: del });
+
+    const success = await removeMilestone(9);
+    expect(supabase.from).toHaveBeenCalledWith('milestones');
+    expect(del).toHaveBeenCalled();
+    expect(eq).toHaveBeenCalledWith('id', 9);
+    expect(success).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- render and manage project milestones with edit and delete actions
- add helper to create or update milestones
- cover milestone CRUD workflows in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e423bec948323b13c033df056afbb