### PR TITLE
feat: enhance password update feedback and tests

### DIFF
--- a/src/components/ProfileEditor.jsx
+++ b/src/components/ProfileEditor.jsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { supabase } from "../supabaseClient";
+import { updatePassword } from "../utils/updatePassword";
 
 // Formular-Komponente zum Bearbeiten der Profildaten eines Nutzers
 const ProfileEditor = ({ user }) => {
+  const navigate = useNavigate();
   const [form, setForm] = useState({
     vorname: "",
     nachname: "",
@@ -52,22 +55,9 @@ const ProfileEditor = ({ user }) => {
     }
 
     if (form.passwort && form.passwort === form.passwortBestätigen) {
-      await updatePassword(form.passwort);
+      await updatePassword(form.passwort, navigate);
     } else if (form.passwort || form.passwortBestätigen) {
       alert("Passwörter stimmen nicht überein");
-    }
-  };
-
-  // Setzt ein neues Passwort für den angemeldeten Nutzer
-  const updatePassword = async (newPassword) => {
-    const { error } = await supabase.auth.updateUser({
-      password: newPassword,
-    });
-
-    if (error) {
-      console.error("Fehler beim Ändern des Passworts:", error.message);
-    } else {
-      alert("Passwort erfolgreich geändert.");
     }
   };
 

--- a/src/utils/__tests__/updatePassword.test.js
+++ b/src/utils/__tests__/updatePassword.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updatePassword } from '../updatePassword.js';
+import { supabase } from '../../supabaseClient.js';
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    auth: {
+      updateUser: vi.fn(),
+      signOut: vi.fn(),
+    },
+  },
+}));
+
+describe('updatePassword', () => {
+  const navigate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handles successful password change', async () => {
+    supabase.auth.updateUser.mockResolvedValue({ data: {}, error: null });
+    globalThis.alert = vi.fn();
+
+    await updatePassword('geheim', navigate);
+
+    expect(globalThis.alert).toHaveBeenCalledWith(
+      'Passwort erfolgreich geändert. Bitte melde dich erneut an.'
+    );
+    expect(supabase.auth.signOut).toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/login');
+  });
+
+  it('handles password change error', async () => {
+    const error = { message: 'oops' };
+    supabase.auth.updateUser.mockResolvedValue({ data: null, error });
+    globalThis.alert = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await updatePassword('geheim', navigate);
+
+    expect(globalThis.alert).toHaveBeenCalledWith(
+      `Fehler beim Ändern des Passworts: ${error.message}`
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      'Fehler beim Ändern des Passworts:',
+      error.message
+    );
+    expect(supabase.auth.signOut).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    console.error.mockRestore();
+  });
+});

--- a/src/utils/updatePassword.js
+++ b/src/utils/updatePassword.js
@@ -1,0 +1,20 @@
+import { supabase } from '../supabaseClient.js';
+
+// Setzt ein neues Passwort für den angemeldeten Nutzer
+// und leitet bei Erfolg zum Login um
+export const updatePassword = async (newPassword, navigate) => {
+  const { error } = await supabase.auth.updateUser({
+    password: newPassword,
+  });
+
+  if (error) {
+    console.error('Fehler beim Ändern des Passworts:', error.message);
+    alert(`Fehler beim Ändern des Passworts: ${error.message}`);
+    return false;
+  }
+
+  alert('Passwort erfolgreich geändert. Bitte melde dich erneut an.');
+  await supabase.auth.signOut();
+  navigate('/login');
+  return true;
+};


### PR DESCRIPTION
## Summary
- add navigation and detailed messages for password changes
- extract password update logic into util
- test password update success and failure paths

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688f0f9881748323b1dc1e5203a73b46