### PR TITLE
Hide profile link when logged out

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -49,9 +49,11 @@ function Navbar() {
     <nav className="bg-white shadow-md px-6 py-4 flex justify-between items-center">
       <h1 className="text-xl font-bold text-blue-600">📘 MyApp</h1>
       <div className="space-x-4">
-        <Link to="/profil" className="text-blue-600 underline">
-        Profil bearbeiten
-        </Link>
+        {user && (
+          <Link to="/profil" className="text-blue-600 underline">
+            Profil bearbeiten
+          </Link>
+        )}
 
         <Link to="/" className="hover:text-blue-600">
           Start

--- a/src/components/__tests__/navbar.test.jsx
+++ b/src/components/__tests__/navbar.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import Navbar from '../Navbar.jsx';
+
+vi.mock('../../supabaseClient.js', () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+      onAuthStateChange: vi
+        .fn()
+        .mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+    },
+  },
+}));
+
+describe('Navbar', () => {
+  it('does not render profile link when logged out', () => {
+    const html = renderToString(
+      <MemoryRouter initialEntries={["/"]}>
+        <Navbar />
+      </MemoryRouter>
+    );
+
+    expect(html).not.toContain('/profil');
+    expect(html).not.toContain('Profil bearbeiten');
+  });
+});
+


### PR DESCRIPTION
## Summary
- show the profile editing link only for logged-in users
- test navbar to ensure profile link is absent when logged out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f224c08488323b578d541ab221656