### PR TITLE
feat: allow multiple project file uploads

### DIFF
--- a/src/components/CommentsSection.jsx
+++ b/src/components/CommentsSection.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../supabaseClient";
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const addComment = async (projectId, userId, content) => {
   const { error } = await supabase
     .from("comments")
@@ -28,7 +29,7 @@ const CommentsSection = ({ projectId, user }) => {
         setComments(data);
         setFeedback(null);
       }
-    } catch (err) {
+    } catch {
       setFeedback({ type: "error", text: "Fehler beim Laden der Kommentare" });
     }
   };
@@ -58,7 +59,7 @@ const CommentsSection = ({ projectId, user }) => {
       setText("");
       setFeedback({ type: "success", text: "Kommentar gespeichert" });
       fetchComments();
-    } catch (err) {
+    } catch {
       setFeedback({ type: "error", text: "Fehler beim Speichern des Kommentars" });
     }
   };


### PR DESCRIPTION
## Summary
- support selecting and uploading multiple project files
- store uploaded file metadata for later display
- clean up CommentsSection linter issues

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f2de231e88323abd5109691a2b28d