### PR TITLE
Add milestone file listing component and tests

### DIFF
--- a/src/components/MilestoneFiles.jsx
+++ b/src/components/MilestoneFiles.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState, useCallback } from "react";
+import { supabase } from "../supabaseClient";
+
+// Zeigt alle gespeicherten Dateien eines Meilensteins an
+const MilestoneFiles = ({ milestoneId }) => {
+  const [files, setFiles] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchFiles = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("milestone_files")
+      .select("id, name, path")
+      .eq("milestone_id", milestoneId);
+
+    if (error) {
+      console.error("Fehler beim Laden der Dateien:", error.message);
+      setFiles([]);
+    } else {
+      setFiles(data || []);
+    }
+    setLoading(false);
+  }, [milestoneId]);
+
+  useEffect(() => {
+    fetchFiles();
+  }, [fetchFiles]);
+
+  const handleDelete = async (file) => {
+    const { error: storageError } = await supabase.storage
+      .from("milestone-files")
+      .remove([file.path]);
+
+    if (storageError) {
+      console.error("Fehler beim Löschen der Datei:", storageError.message);
+      return;
+    }
+
+    const { error } = await supabase
+      .from("milestone_files")
+      .delete()
+      .eq("id", file.id);
+
+    if (error) {
+      console.error("Fehler beim Löschen der Datei:", error.message);
+    } else {
+      fetchFiles();
+    }
+  };
+
+  if (loading) return <p>📁 Dateien werden geladen...</p>;
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-lg font-semibold mb-2">📂 Meilensteindateien</h2>
+      {files.length === 0 && <p>Keine Dateien vorhanden.</p>}
+      <ul>
+        {files.map((file) => {
+          const {
+            data: { publicUrl },
+          } = supabase.storage
+            .from("milestone-files")
+            .getPublicUrl(file.path);
+
+          return (
+            <li key={file.id} className="mb-1 flex items-center space-x-2">
+              <span>{file.name}</span>
+              <a
+                href={publicUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                download
+                className="text-blue-600 text-sm underline"
+              >
+                Download
+              </a>
+              <button
+                onClick={() => handleDelete(file)}
+                className="text-red-500 text-sm"
+              >
+                Löschen
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default MilestoneFiles;

--- a/src/components/__tests__/milestoneFiles.test.js
+++ b/src/components/__tests__/milestoneFiles.test.js
@@ -1,0 +1,119 @@
+vi.mock('react', async () => {
+  const actual = await vi.importActual('react');
+  return { ...actual, useState: vi.fn(), useEffect: vi.fn() };
+});
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React, { useState, useEffect } from 'react';
+import { renderToString } from 'react-dom/server';
+import MilestoneFiles from '../MilestoneFiles.jsx';
+import { supabase, storageStore, dbStore } from '../../supabaseClient.js';
+
+vi.mock('../../supabaseClient.js', () => {
+  const storageStore = {};
+  const dbStore = {};
+
+  const storage = {
+    upload: vi.fn(async (path, file) => {
+      const parts = path.split('/');
+      const dir = parts.slice(0, -1).join('/');
+      const name = parts.pop();
+      if (!storageStore[dir]) storageStore[dir] = [];
+      storageStore[dir].push({ name, path });
+      return { data: {}, error: null };
+    }),
+    remove: vi.fn(async (paths) => {
+      paths.forEach((p) => {
+        const dir = p.split('/').slice(0, -1).join('/');
+        const name = p.split('/').pop();
+        if (storageStore[dir]) {
+          storageStore[dir] = storageStore[dir].filter((f) => f.name !== name);
+        }
+      });
+      return { data: {}, error: null };
+    }),
+    list: vi.fn(async (path) => ({ data: storageStore[path] || [], error: null })),
+    getPublicUrl: vi.fn((path) => ({
+      data: { publicUrl: `https://example.com/${path}` },
+    })),
+  };
+
+  const from = vi.fn((table) => {
+    if (table === 'milestone_files') {
+      return {
+        insert: vi.fn(async (rows) => {
+          rows.forEach((r) => {
+            if (!dbStore[r.milestone_id]) dbStore[r.milestone_id] = [];
+            dbStore[r.milestone_id].push({
+              id: r.id || r.name,
+              name: r.name,
+              path: r.path,
+            });
+          });
+          return { data: {}, error: null };
+        }),
+        delete: vi.fn(() => ({
+          eq: vi.fn(async (col, value) => {
+            Object.keys(dbStore).forEach((k) => {
+              dbStore[k] = dbStore[k].filter((f) => f.id !== value);
+            });
+            return { data: {}, error: null };
+          }),
+        })),
+        select: vi.fn(() => ({
+          eq: vi.fn(async (col, value) => ({
+            data: dbStore[value] || [],
+            error: null,
+          })),
+        })),
+      };
+    }
+    return {};
+  });
+
+  return {
+    supabase: { storage: { from: () => storage }, from },
+    storageStore,
+    dbStore,
+  };
+});
+
+describe('MilestoneFiles', () => {
+  beforeEach(() => {
+    Object.keys(storageStore).forEach((k) => delete storageStore[k]);
+    Object.keys(dbStore).forEach((k) => delete dbStore[k]);
+    useState.mockReset();
+    useEffect.mockReset();
+    vi.clearAllMocks();
+  });
+
+  it('renders uploaded files with delete buttons', async () => {
+    const milestoneId = 1;
+    const testFiles = [{ name: 'a.txt' }, { name: 'b.txt' }];
+
+    const bucket = supabase.storage.from('milestone-files');
+    for (const file of testFiles) {
+      const path = `milestone/${milestoneId}/${file.name}`;
+      await bucket.upload(path, file);
+      await supabase
+        .from('milestone_files')
+        .insert([{ name: file.name, path, milestone_id: milestoneId }]);
+    }
+
+    const uploaded = dbStore[milestoneId];
+
+    useState
+      .mockImplementationOnce(() => [uploaded, vi.fn()])
+      .mockImplementationOnce(() => [false, vi.fn()]);
+    useEffect.mockImplementation(() => {});
+
+    const html = renderToString(
+      React.createElement(MilestoneFiles, { milestoneId })
+    );
+
+    testFiles.forEach((file) => {
+      expect(html).toContain(file.name);
+      expect(html).toContain('Löschen');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `MilestoneFiles` component to display and delete milestone-specific files
- mock Supabase storage and table calls in new test
- verify rendering of uploaded files and delete controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f44075b008323a4cd7da98b182a7d