### PR TITLE
feat: add milestone file uploads

### DIFF
--- a/src/components/MilestoneList.jsx
+++ b/src/components/MilestoneList.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable react-refresh/only-export-components */
 // src/components/MilestoneList.jsx
-import { useEffect, useState } from "react";
+import { useEffect, useState, Fragment } from "react";
 import { supabase } from "../supabaseClient";
+import MilestoneFiles from "./MilestoneFiles.jsx";
 
 // Löscht einen Meilenstein
 // eslint-disable-next-line react-refresh/only-export-components
@@ -80,28 +81,35 @@ const MilestoneList = ({ projectId }) => {
       </thead>
       <tbody>
         {milestones.map((m) => (
-          <tr key={m.id}>
-            <td className="p-2 border">{m.title}</td>
-            <td className="p-2 border">{m.description}</td>
-            <td className="p-2 border">
-              {m.due_date ? new Date(m.due_date).toLocaleDateString() : "-"}
-            </td>
-            <td className="p-2 border">{m.status}</td>
-            <td className="p-2 border space-x-2">
-              <button
-                className="text-blue-600 underline"
-                onClick={() => handleEdit(m)}
-              >
-                Bearbeiten
-              </button>
-              <button
-                className="text-red-600 underline"
-                onClick={() => handleDelete(m.id)}
-              >
-                Löschen
-              </button>
-            </td>
-          </tr>
+          <Fragment key={m.id}>
+            <tr>
+              <td className="p-2 border">{m.title}</td>
+              <td className="p-2 border">{m.description}</td>
+              <td className="p-2 border">
+                {m.due_date ? new Date(m.due_date).toLocaleDateString() : "-"}
+              </td>
+              <td className="p-2 border">{m.status}</td>
+              <td className="p-2 border space-x-2">
+                <button
+                  className="text-blue-600 underline"
+                  onClick={() => handleEdit(m)}
+                >
+                  Bearbeiten
+                </button>
+                <button
+                  className="text-red-600 underline"
+                  onClick={() => handleDelete(m.id)}
+                >
+                  Löschen
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td colSpan="5" className="p-2 border bg-gray-50">
+                <MilestoneFiles projectId={projectId} milestoneId={m.id} />
+              </td>
+            </tr>
+          </Fragment>
         ))}
       </tbody>
     </table>

--- a/src/components/__tests__/milestoneFiles.test.js
+++ b/src/components/__tests__/milestoneFiles.test.js
@@ -88,12 +88,13 @@ describe('MilestoneFiles', () => {
   });
 
   it('renders uploaded files with delete buttons', async () => {
+    const projectId = 1;
     const milestoneId = 1;
     const testFiles = [{ name: 'a.txt' }, { name: 'b.txt' }];
 
-    const bucket = supabase.storage.from('milestone-files');
+    const bucket = supabase.storage.from('project-files');
     for (const file of testFiles) {
-      const path = `milestone/${milestoneId}/${file.name}`;
+      const path = `project/${projectId}/milestone/${milestoneId}/${file.name}`;
       await bucket.upload(path, file);
       await supabase
         .from('milestone_files')
@@ -108,7 +109,7 @@ describe('MilestoneFiles', () => {
     useEffect.mockImplementation(() => {});
 
     const html = renderToString(
-      React.createElement(MilestoneFiles, { milestoneId })
+      React.createElement(MilestoneFiles, { projectId, milestoneId })
     );
 
     testFiles.forEach((file) => {

--- a/supabase/migrations/20250219000000_create_milestone_files.sql
+++ b/supabase/migrations/20250219000000_create_milestone_files.sql
@@ -1,0 +1,7 @@
+create table if not exists milestone_files (
+  id bigint generated always as identity primary key,
+  milestone_id bigint references milestones(id) on delete cascade,
+  path text not null,
+  name text not null,
+  uploaded_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add SQL migration for `milestone_files`
- allow uploading, listing and deleting milestone files
- show milestone files under each milestone

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f3b64fbf883239f633bf3326dc9a1